### PR TITLE
Update m2crypto to 0.38.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=['M2Crypto==0.35.2'],
+    install_requires=['M2Crypto==0.38.0'],
     description="Pure Python3 implementation to sign JAR and APK files",
     long_description="pure Python3 implementation to sign JAR and APK files "
         "which was inspired and borrowed from python-javatools",


### PR DESCRIPTION
m2crypto 0.35.2 failing installation: with error
```
SWIG/_m2crypto_wrap.c:32481:102: error: use of undeclared identifier 'RSA_SSLV23_PADDING'
  SWIG_Python_SetConstant(d, d == md ? public_interface : NULL, "sslv23_padding",SWIG_From_int((int)(RSA_SSLV23_PADDING)));
```
`RSA_SSLV23_PADDING` was made optional in 0.38.0
https://gitlab.com/m2crypto/m2crypto/-/blob/master/CHANGES#L7
